### PR TITLE
fix: add constant to SAS Parser AAC-36708

### DIFF
--- a/src/main/java/com/epam/parso/impl/SasFileParser.java
+++ b/src/main/java/com/epam/parso/impl/SasFileParser.java
@@ -106,6 +106,7 @@ public final class SasFileParser {
         tmpMap.put(0xFCFFFFFFFFFFFFFFL, SubheaderIndexes.COLUMN_ATTRIBUTES_SUBHEADER_INDEX);
         tmpMap.put(0xFEFBFFFFFFFFFFFFL, SubheaderIndexes.FORMAT_AND_LABEL_SUBHEADER_INDEX);
         tmpMap.put(0xFEFFFFFFFFFFFFFFL, SubheaderIndexes.COLUMN_LIST_SUBHEADER_INDEX);
+        // Add 0xFFFFFFF8 to prevent uncompressed data from being incorrectly detected as compressed (AAC-36269)
         tmpMap.put((long) 0xFFFFFFF8, SubheaderIndexes.COLUMN_ATTRIBUTES_SUBHEADER_INDEX);
         SUBHEADER_SIGNATURE_TO_INDEX = Collections.unmodifiableMap(tmpMap);
     }

--- a/src/main/java/com/epam/parso/impl/SasFileParser.java
+++ b/src/main/java/com/epam/parso/impl/SasFileParser.java
@@ -106,6 +106,7 @@ public final class SasFileParser {
         tmpMap.put(0xFCFFFFFFFFFFFFFFL, SubheaderIndexes.COLUMN_ATTRIBUTES_SUBHEADER_INDEX);
         tmpMap.put(0xFEFBFFFFFFFFFFFFL, SubheaderIndexes.FORMAT_AND_LABEL_SUBHEADER_INDEX);
         tmpMap.put(0xFEFFFFFFFFFFFFFFL, SubheaderIndexes.COLUMN_LIST_SUBHEADER_INDEX);
+        tmpMap.put((long) 0xFFFFFFF8, SubheaderIndexes.COLUMN_ATTRIBUTES_SUBHEADER_INDEX);
         SUBHEADER_SIGNATURE_TO_INDEX = Collections.unmodifiableMap(tmpMap);
     }
 


### PR DESCRIPTION
Forked library has not been updated since 2021.
This is a temporary fix, we'll need to consider switching to a new library in the future.
Ticket: [https://yseop-knowledge.atlassian.net/browse/AAC-36708](https://yseop-knowledge.atlassian.net/browse/AAC-36708)
